### PR TITLE
fix: postId 페이지 배경 이미지 어두운 색감 추가

### DIFF
--- a/src/components/PostId/PostIdMain.jsx
+++ b/src/components/PostId/PostIdMain.jsx
@@ -3,7 +3,11 @@ import styles from "./PostIdMain.module.scss";
 function PostIdMain({ children, bgColor = "", bgImg = null }) {
   return (
     <main
-      style={{ backgroundImage: `url(${bgImg})` }}
+      style={
+        bgImg && {
+          backgroundImage: `linear-gradient(rgba(0, 0, 0, 0.54), rgba(0, 0, 0, 0.54)), url(${bgImg})`,
+        }
+      }
       className={`${styles.main} ${styles[bgColor]}`}
     >
       {children}


### PR DESCRIPTION
## 📝작업 내용

배경 이미지에 어두운 색감 넣었습니다.


### 📸스크린샷
![이미지 배경](https://github.com/sprint5-part2-team9/Rolling/assets/41028065/1e082e68-1cd6-4af6-b1a0-612b4a94f565)

![색배경](https://github.com/sprint5-part2-team9/Rolling/assets/41028065/66d874d3-dcc5-4b07-9d2e-e19524ff9e22)

색배경은 변화 없음
***
### 💬리뷰 요구사항
